### PR TITLE
Expose root health endpoint and update npm lifecycle to run backend

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -22,6 +22,14 @@ function getMissingEnvVars() {
 app.use(cors({ origin: corsOrigin }))
 app.use(express.json())
 
+app.get("/", (req, res) => {
+    return res.status(200).json({
+        status: "ok",
+        message: "AI Issue Solver backend is running",
+        health: "/health"
+    })
+})
+
 app.get("/health", (req, res) => {
     const missingEnv = getMissingEnvVars()
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "start": "node server.js"
+    "postinstall": "npm install --prefix backend",
+    "start": "npm start --prefix backend"
   },
   "dependencies": {
     "openai": "^6.27.0"


### PR DESCRIPTION
### Motivation
- Provide a lightweight root endpoint for quick service checks and to advertise the health endpoint.
- Make the repository-level `npm` lifecycle install and start the `backend` service in a multi-package layout.

### Description
- Add `GET /` endpoint in `backend/server.js` that returns a basic JSON status and points to `/health`.
- Keep existing `/health` endpoint that reports missing required environment variables.
- Update top-level `package.json` to run `npm install --prefix backend` on `postinstall` and to use `npm start --prefix backend` for the `start` script so the backend is installed and started from the repository root.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5d87ee82c8327813a12742b597f68)