### PR TITLE
Add root health route, improve frontend API URL resolution, and update start scripts

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -22,6 +22,14 @@ function getMissingEnvVars() {
 app.use(cors({ origin: corsOrigin }))
 app.use(express.json())
 
+app.get("/", (req, res) => {
+    return res.status(200).json({
+        status: "ok",
+        message: "AI Issue Solver backend is running",
+        health: "/health"
+    })
+})
+
 app.get("/health", (req, res) => {
     const missingEnv = getMissingEnvVars()
 

--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -1,7 +1,32 @@
 import React from 'react'
 import axios from "axios"
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:5000"
+function resolveApiBaseUrl() {
+  const configuredUrl = import.meta.env.VITE_API_BASE_URL?.trim()
+
+  if (configuredUrl) {
+    return configuredUrl.replace(/\/$/, "")
+  }
+
+  if (typeof window !== "undefined") {
+    const { hostname, origin } = window.location
+    const isLocalhost = hostname === "localhost" || hostname === "127.0.0.1"
+
+    if (isLocalhost) {
+      return "http://localhost:5000"
+    }
+
+    if (hostname.includes("frontend")) {
+      return origin.replace("frontend", "backend")
+    }
+
+    return origin
+  }
+
+  return "http://localhost:5000"
+}
+
+const API_BASE_URL = resolveApiBaseUrl()
 
 export function SolveButton({ issueNumber }) {
   const handleSolve = () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "start": "node server.js"
+    "postinstall": "npm install --prefix backend",
+    "start": "npm start --prefix backend"
   },
   "dependencies": {
     "openai": "^6.27.0"


### PR DESCRIPTION
### Motivation

- Provide a lightweight liveness/root endpoint so deployments can quickly verify the backend is reachable.
- Make the frontend resilient to different deployment topologies by deriving the API base URL from env or `window.location` heuristics.
- Ensure backend dependencies are installed and the server starts correctly when running from the repository root.

### Description

- Added a root `GET /` endpoint in `backend/server.js` that returns basic status info and a pointer to `/health`.
- Implemented `resolveApiBaseUrl()` in `frontend/App.jsx` to use `VITE_API_BASE_URL` (trimmed and with trailing slash removed), fall back to `window.location` heuristics for `localhost`, replace `frontend` with `backend` when appropriate, and otherwise default to `http://localhost:5000`.
- Updated `package.json` scripts to run `postinstall` with `npm install --prefix backend` and to start the backend via `npm start --prefix backend` from repository root.

### Testing

- No automated tests were present for these changes and no automated test suite was executed for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5d87ee82c8327813a12742b597f68)