### PR TITLE
Add robust Gemini model fallback and configurable `GEMINI_MODEL`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ This repo includes a `render.yaml` blueprint that provisions two services:
    - `GITHUB_OWNER`
    - `GITHUB_REPO`
    - `GEMINI_API_KEY`
+   - `GEMINI_MODEL` (optional, defaults to `gemini-2.0-flash` with fallback support)
 5. Update domains in `render.yaml` to match your real Render service URLs:
    - `CORS_ORIGIN` on backend
    - `VITE_API_BASE_URL` on frontend
@@ -90,7 +91,7 @@ curl https://<your-backend-service>.onrender.com/health
 ## Development notes
 
 - `backend/githubService.js` contains GitHub API helpers (`getIssue`, `createPullRequest`).
-- `backend/aiService.js` talks to Gemini; modify the prompt for different behavior.
+- `backend/aiService.js` talks to Gemini; it uses `GEMINI_MODEL` when provided and falls back across supported models.
 - `backend/agent.js` orchestrates the flow and handles errors.
 - The server supports `PORT` and `CORS_ORIGIN` environment variables for deployment.
 

--- a/backend/aiService.js
+++ b/backend/aiService.js
@@ -2,12 +2,21 @@ const { GoogleGenerativeAI } = require("@google/generative-ai")
 
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY)
 
-async function generatePatch(issueText){
+const configuredModel = process.env.GEMINI_MODEL?.trim()
+const modelCandidates = [
+    configuredModel,
+    "gemini-2.0-flash",
+    "gemini-1.5-flash"
+].filter(Boolean)
 
-    const model = genAI.getGenerativeModel({
-        model: "gemini-1.5-flash"
-    })
+function isModelNotFoundError(error) {
+    return typeof error?.message === "string" &&
+        error.message.includes("404") &&
+        error.message.includes("models/") &&
+        error.message.includes("generateContent")
+}
 
+async function generatePatch(issueText) {
     const prompt = `
 You are an AI developer.
 
@@ -19,9 +28,28 @@ Issue:
 ${issueText}
 `
 
-    const result = await model.generateContent(prompt)
+    let lastError
 
-    return result.response.text()
+    for (const modelName of modelCandidates) {
+        try {
+            const model = genAI.getGenerativeModel({ model: modelName })
+            const result = await model.generateContent(prompt)
+            return result.response.text()
+        } catch (error) {
+            lastError = error
+
+            if (isModelNotFoundError(error)) {
+                console.warn(`Gemini model '${modelName}' is unavailable for generateContent, trying fallback model.`)
+                continue
+            }
+
+            throw error
+        }
+    }
+
+    throw new Error(
+        `No configured Gemini model is available for generateContent. Tried: ${modelCandidates.join(", ")}. Last error: ${lastError?.message || "unknown error"}`
+    )
 }
 
 module.exports = { generatePatch }


### PR DESCRIPTION
### Motivation
- The previous hardcoded Gemini model caused failures when a model ID was unavailable for `generateContent` (404/not-supported), so the service needs to try alternate models and allow configuration.
- Make it easy to prefer a newer/default model while retaining backwards-compatible fallbacks.

### Description
- Read an optional `GEMINI_MODEL` environment variable and build an ordered candidate list (`GEMINI_MODEL`, `gemini-2.0-flash`, `gemini-1.5-flash`) in `backend/aiService.js`.
- Add a retry loop that attempts `generateContent` for each candidate and only falls back when the error indicates a model-not-found/unsupported 404, while rethrowing other errors immediately.
- Implement `isModelNotFoundError` to detect 404 model-not-found/unsupported errors and improve the final error message to include attempted models and the last error.
- Update `README.md` to document the optional `GEMINI_MODEL` env var and note the aiService fallback behavior.

### Testing
- Ran `cd backend && node -e "const { generatePatch } = require('./aiService'); console.log(typeof generatePatch)"` to verify the exported function is available, and it printed `function` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d67298ecb083279ecf829f7824166d)